### PR TITLE
dependencies: add util-linux; remove checking for posix utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ I made this script since there are no init independent zram-related scripts and/
 
 It will run on any POSIX-Compliant shell, init system, coreutilities (Tested on chimerautils)
 
-## Dependencies
+## Userspace Dependencies
 
-Right now, it only needs `cat`, `grep` and `bc`
+A posix compliant environment, and util-linux (for `mkswap`, `swapon`, and `zramctl`).

--- a/zramd
+++ b/zramd
@@ -3,8 +3,6 @@
 zramCompress=zstd
 zramDevice=zram0
 
-# TODO: Check if the user has the following utilities installed `cat`, `grep`, `bc`.
-
 ramSize=$(grep -i 'memtotal' /proc/meminfo | grep -o '[[:digit:]]*' | bc)
 zramSize=$(("${ramSize}" / 2))
 


### PR DESCRIPTION
There is little point checking for cat(1), grep(1), and bc(1) as they are already mandated by POSIX. A future commit can ensure exiting early if a command fails.